### PR TITLE
Move credit card tokenization to post transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ The plugin supports:
 3. Purchase (auth with capture)
 4. Refund
 
-Tokenization is done via a $0 dollar authorization, be sure to check that this is allowed by the financial institution being used by Checkout.com
-
 
 Installation
 --------------------------------------------------------------------------------
@@ -22,6 +20,7 @@ Once an account is provisioned the secret key will need to be installed into the
 
     checkoutdotcom:
       secret_key: sk_test_XXXXXXX
+      test: true # set this to false in production.
 
 The secret key can be found in the **Channels** tab in the **Settings** section of the Checkout.com hub.
 

--- a/app/models/workarea/payment/authorize/credit_card.decorator
+++ b/app/models/workarea/payment/authorize/credit_card.decorator
@@ -4,6 +4,23 @@ module Workarea
       delegate :address, to: :tender
     end
 
+     def complete!
+      transaction.response = handle_active_merchant_errors do
+        gateway.authorize(
+          transaction.amount.cents,
+          tender.to_token_or_active_merchant,
+          transaction_options
+        )
+      end
+
+      if transaction.response.success? && tender.token.blank?
+        tender.token = transaction.response.params["source"]["id"]
+        tender.save!
+      end
+
+      transaction.response
+    end
+
     private
 
     def transaction_options

--- a/app/models/workarea/payment/purchase/credit_card.decorator
+++ b/app/models/workarea/payment/purchase/credit_card.decorator
@@ -4,6 +4,23 @@ module Workarea
       delegate :address, to: :tender
     end
 
+    def complete!
+      transaction.response = handle_active_merchant_errors do
+        gateway.purchase(
+          transaction.amount.cents,
+          tender.to_token_or_active_merchant,
+          transaction_options
+        )
+      end
+
+      if transaction.response.success? && tender.token.blank?
+        tender.token = transaction.response.params["source"]["id"]
+        tender.save!
+
+      end
+      transaction.response
+    end
+
     private
 
     def transaction_options

--- a/lib/active_merchant/billing/bogus_checkout_v2_gateway.rb
+++ b/lib/active_merchant/billing/bogus_checkout_v2_gateway.rb
@@ -13,6 +13,30 @@ module ActiveMerchant
           raise Error, error_message(paysource)
         end
       end
+
+      def authorize_swipe(money, paysource, options = {})
+        money = amount(money)
+        case normalize(paysource)
+        when /1$/, AUTHORIZATION
+          Response.new(true, SUCCESS_MESSAGE, { "source" => { "id" => "111", "customerId" => "cust_123" }, "authorized_amount" => money }, test: true, authorization: AUTHORIZATION)
+        when /2$/
+          Response.new(false, FAILURE_MESSAGE, { authorized_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
+        else
+          raise Error, error_message(paysource)
+        end
+      end
+
+      def purchase_swipe(money, paysource, options = {})
+        money = amount(money)
+        case normalize(paysource)
+        when /1$/, AUTHORIZATION
+          Response.new(true, SUCCESS_MESSAGE, { "source" => { "id" => "111", "customerId" => "cust_123" }, "paid_amount" => money }, test: true, authorization: AUTHORIZATION)
+        when /2$/
+          Response.new(false, FAILURE_MESSAGE, { paid_amount: money, error: FAILURE_MESSAGE }, test: true, error_code: STANDARD_ERROR_CODE[:processing_error])
+        else
+          raise Error, error_message(paysource)
+        end
+      end
     end
   end
 end

--- a/test/models/workarea/payment/authorize/credit_card_test.decorator
+++ b/test/models/workarea/payment/authorize/credit_card_test.decorator
@@ -1,5 +1,9 @@
 module Workarea
   decorate Payment::Authorize::CreditCardTest, with: :checkoutdotcom do
+    def test_complete_does_nothing_if_gateway_storage_fails
+      skip "Storage happens post transaction"
+    end
+
     def payment
       @payment ||= create_payment(profile: create_payment_profile)
     end

--- a/test/models/workarea/payment/purchase/credit_card_test.decorator
+++ b/test/models/workarea/payment/purchase/credit_card_test.decorator
@@ -1,5 +1,9 @@
 module Workarea
   decorate Payment::Purchase::CreditCardTest, with: :checkoutdotcom do
+    def test_complete_does_nothing_if_gateway_storage_fails
+      skip "Storage happens post transaction"
+    end
+
     def payment
       @payment ||= create_payment(profile: create_payment_profile)
     end

--- a/test/vcr_cassettes/checkoutdotcom/auth_capture.yml
+++ b/test/vcr_cassettes/checkoutdotcom/auth_capture.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_ulv5vm5ekoauvb5yqc7olwuyge
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 2d967375-3d35-4de4-81b4-428c5769bce4
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:14 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_ulv5vm5ekoauvb5yqc7olwuyge","action_id":"act_ulv5vm5ekoauvb5yqc7olwuyge","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"847342","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:14Z","processing":{"acquirer_transaction_id":"8138703044","retrieval_reference_number":"000847342548"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_ulv5vm5ekoauvb5yqc7olwuyge"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_ulv5vm5ekoauvb5yqc7olwuyge/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_ulv5vm5ekoauvb5yqc7olwuyge/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_ulv5vm5ekoauvb5yqc7olwuyge/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:14 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_ulv5vm5ekoauvb5yqc7olwuyge/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - d15992c6-beb3-4110-a7e9-a8ed7fdd5a7a
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:15 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_2qqrtchsj76ebi6enntuwbes44","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_ulv5vm5ekoauvb5yqc7olwuyge"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:15 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":"BC7AE3FE3D","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":"86C68AD158","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":"user@workarea.com"}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1538'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1385'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_wzpqhljt6ksepl7y32k7tij3c4
+      - https://api.sandbox.checkout.com/payments/pay_ngd7bxo3ofxupk67tzqz4jfrji
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - cbbdec14-d877-470a-8b7f-87f31e529562
+      - 14e40949-a8d5-48ee-b5f3-5f49c5e0b137
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,22 +56,33 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:16 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:08:00 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21930-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194080.679938,VS0,VE412
     body:
       encoding: UTF-8
-      string: '{"id":"pay_wzpqhljt6ksepl7y32k7tij3c4","action_id":"act_wzpqhljt6ksepl7y32k7tij3c4","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"788539","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_ngd7bxo3ofxupk67tzqz4jfrji","action_id":"act_ngd7bxo3ofxupk67tzqz4jfrji","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"741933","eci":"05","scheme_id":"090091145295585","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_toxd2yvjsdlelieckfowkotabq","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:16Z","reference":"BC7AE3FE3D","processing":{"acquirer_transaction_id":"8138703047","retrieval_reference_number":"000788539479"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_wzpqhljt6ksepl7y32k7tij3c4"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_wzpqhljt6ksepl7y32k7tij3c4/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_wzpqhljt6ksepl7y32k7tij3c4/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_wzpqhljt6ksepl7y32k7tij3c4/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_xwtxqa3y66euhnkwgpcwe7ijce","email":"user@workarea.com","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:08:00Z","reference":"86C68AD158","processing":{"acquirer_transaction_id":"6628523198","retrieval_reference_number":"878497707083"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_ngd7bxo3ofxupk67tzqz4jfrji"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_ngd7bxo3ofxupk67tzqz4jfrji/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_ngd7bxo3ofxupk67tzqz4jfrji/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_ngd7bxo3ofxupk67tzqz4jfrji/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:16 GMT
+  recorded_at: Tue, 19 Nov 2019 20:08:00 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_wzpqhljt6ksepl7y32k7tij3c4/captures
+    uri: https://api.sandbox.checkout.com/payments/pay_ngd7bxo3ofxupk67tzqz4jfrji/captures
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -215,12 +104,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '176'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '176'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -228,9 +119,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 452a5ff6-ed61-4971-aa05-a22b15b14612
+      - 0b627c12-16de-4340-9311-07039f962fdd
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -241,13 +132,23 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:17 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:08:00 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21924-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194080.362314,VS0,VE159
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_d2cwirghihjuze3kbvihcmmaqy","reference":"BC7AE3FE3D","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_wzpqhljt6ksepl7y32k7tij3c4"}}}'
+      string: '{"action_id":"act_tk3yswek5sdevcif7tzd3qdcne","reference":"86C68AD158","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_ngd7bxo3ofxupk67tzqz4jfrji"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:17 GMT
+  recorded_at: Tue, 19 Nov 2019 20:08:00 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/checkoutdotcom/auth_capture_refund.yml
+++ b/test/vcr_cassettes/checkoutdotcom/auth_capture_refund.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_mqbgi4yeegoefaau5sejl6elka
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 8e0a98b8-509e-48d1-b46f-3536e2d5edd2
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:06 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_mqbgi4yeegoefaau5sejl6elka","action_id":"act_mqbgi4yeegoefaau5sejl6elka","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"895570","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:02Z","processing":{"acquirer_transaction_id":"8138703018","retrieval_reference_number":"000895570930"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_mqbgi4yeegoefaau5sejl6elka"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_mqbgi4yeegoefaau5sejl6elka/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_mqbgi4yeegoefaau5sejl6elka/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_mqbgi4yeegoefaau5sejl6elka/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:06 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_mqbgi4yeegoefaau5sejl6elka/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 05f201be-cc4f-4ba9-a939-a84fb9bffa71
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:09 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_ziigx3dmdzmupnnmsf6hdbtw6e","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_mqbgi4yeegoefaau5sejl6elka"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:09 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":"95BD522186","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":"00E7A6C7A4","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":"user@workarea.com"}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1538'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1385'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_aao2kefrqywebj643e567zga7u
+      - https://api.sandbox.checkout.com/payments/pay_u26oibpqa4hefirszv7opfy2ty
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 33072227-9b2f-43fe-935b-6a33136ed07b
+      - e04849b7-8f81-4413-9920-389cb8a238e5
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,22 +56,33 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:10 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:07:50 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21922-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194070.041390,VS0,VE450
     body:
       encoding: UTF-8
-      string: '{"id":"pay_aao2kefrqywebj643e567zga7u","action_id":"act_aao2kefrqywebj643e567zga7u","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"887260","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_u26oibpqa4hefirszv7opfy2ty","action_id":"act_u26oibpqa4hefirszv7opfy2ty","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"365568","eci":"05","scheme_id":"570895001372849","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_toxd2yvjsdlelieckfowkotabq","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:09Z","reference":"95BD522186","processing":{"acquirer_transaction_id":"8138703026","retrieval_reference_number":"000887260624"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_aao2kefrqywebj643e567zga7u"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_aao2kefrqywebj643e567zga7u/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_aao2kefrqywebj643e567zga7u/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_aao2kefrqywebj643e567zga7u/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_xwtxqa3y66euhnkwgpcwe7ijce","email":"user@workarea.com","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:07:50Z","reference":"00E7A6C7A4","processing":{"acquirer_transaction_id":"6585623337","retrieval_reference_number":"031253509280"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_u26oibpqa4hefirszv7opfy2ty"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_u26oibpqa4hefirszv7opfy2ty/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_u26oibpqa4hefirszv7opfy2ty/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_u26oibpqa4hefirszv7opfy2ty/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:10 GMT
+  recorded_at: Tue, 19 Nov 2019 20:07:50 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_aao2kefrqywebj643e567zga7u/captures
+    uri: https://api.sandbox.checkout.com/payments/pay_u26oibpqa4hefirszv7opfy2ty/captures
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -215,12 +104,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '176'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '176'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -228,9 +119,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 854e276b-9a7c-4100-9419-c1a3c1a6f0a3
+      - f75d2c75-d9eb-4f00-851b-e4cd6c3466f1
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -241,18 +132,28 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:11 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:07:51 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21937-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194071.727972,VS0,VE408
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_x65uhanenfxexnoxwrrsxwwruy","reference":"95BD522186","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_aao2kefrqywebj643e567zga7u"}}}'
+      string: '{"action_id":"act_w7nek47va4sundka2qguoh4c5q","reference":"00E7A6C7A4","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_u26oibpqa4hefirszv7opfy2ty"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:11 GMT
+  recorded_at: Tue, 19 Nov 2019 20:07:51 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_aao2kefrqywebj643e567zga7u/refunds
+    uri: https://api.sandbox.checkout.com/payments/pay_u26oibpqa4hefirszv7opfy2ty/refunds
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -274,12 +175,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '176'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '176'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -287,9 +190,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 6994069d-acc9-4ee3-86ab-888bd6ca3f46
+      - 30610915-6d1e-4cfe-a070-1ae0d22a34fd
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -300,13 +203,23 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:12 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:07:51 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21948-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194072.541302,VS0,VE438
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_z2obpjvkodvercml7tvdoccque","reference":"95BD522186","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_aao2kefrqywebj643e567zga7u"}}}'
+      string: '{"action_id":"act_7m6r34ltosmepicxr4qkoxbypq","reference":"00E7A6C7A4","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_u26oibpqa4hefirszv7opfy2ty"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:13 GMT
+  recorded_at: Tue, 19 Nov 2019 20:07:52 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/checkoutdotcom/auth_void.yml
+++ b/test/vcr_cassettes/checkoutdotcom/auth_void.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_7rfs4c32qpeuhm36vkvwpciy6i
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 88b15e6b-fd88-4113-9a94-9960ffc17783
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:24 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_7rfs4c32qpeuhm36vkvwpciy6i","action_id":"act_7rfs4c32qpeuhm36vkvwpciy6i","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"992504","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:23Z","processing":{"acquirer_transaction_id":"8138703061","retrieval_reference_number":"000992504906"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_7rfs4c32qpeuhm36vkvwpciy6i"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_7rfs4c32qpeuhm36vkvwpciy6i/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_7rfs4c32qpeuhm36vkvwpciy6i/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_7rfs4c32qpeuhm36vkvwpciy6i/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:24 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_7rfs4c32qpeuhm36vkvwpciy6i/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 5bbe3e0b-dad7-44ef-ab2b-bc59fdd503a8
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:24 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_s63k6o4gincelgjacy4yiny6lu","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_7rfs4c32qpeuhm36vkvwpciy6i"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:25 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":"18D05F3ECC","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":"01655CBB31","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":"user@workarea.com"}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1538'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1385'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_lm63wuapkqculicy3bc4bzj3sy
+      - https://api.sandbox.checkout.com/payments/pay_iafledv5gz7ezleugdlzlk7uvm
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 477c9460-702d-44fd-aef6-9d5ea8886633
+      - 10fbca33-5cba-42fb-99f4-df97c93b8626
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,22 +56,33 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:26 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:07:56 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21924-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194076.430199,VS0,VE403
     body:
       encoding: UTF-8
-      string: '{"id":"pay_lm63wuapkqculicy3bc4bzj3sy","action_id":"act_lm63wuapkqculicy3bc4bzj3sy","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"363686","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_iafledv5gz7ezleugdlzlk7uvm","action_id":"act_iafledv5gz7ezleugdlzlk7uvm","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"723458","eci":"05","scheme_id":"060762178033533","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_toxd2yvjsdlelieckfowkotabq","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:26Z","reference":"18D05F3ECC","processing":{"acquirer_transaction_id":"8138703065","retrieval_reference_number":"000363686314"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_lm63wuapkqculicy3bc4bzj3sy"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_lm63wuapkqculicy3bc4bzj3sy/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_lm63wuapkqculicy3bc4bzj3sy/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_lm63wuapkqculicy3bc4bzj3sy/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_xwtxqa3y66euhnkwgpcwe7ijce","email":"user@workarea.com","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:07:56Z","reference":"01655CBB31","processing":{"acquirer_transaction_id":"6711907989","retrieval_reference_number":"742612877090"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_iafledv5gz7ezleugdlzlk7uvm"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_iafledv5gz7ezleugdlzlk7uvm/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_iafledv5gz7ezleugdlzlk7uvm/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_iafledv5gz7ezleugdlzlk7uvm/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:26 GMT
+  recorded_at: Tue, 19 Nov 2019 20:07:56 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_lm63wuapkqculicy3bc4bzj3sy/voids
+    uri: https://api.sandbox.checkout.com/payments/pay_iafledv5gz7ezleugdlzlk7uvm/voids
     body:
       encoding: UTF-8
       string: "{}"
@@ -215,12 +104,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '176'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '176'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -228,9 +119,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - b2277513-6c26-449c-b772-b71eafea6196
+      - 7b3cb4aa-5d36-4bdd-9cba-f55adf2a013b
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -241,13 +132,23 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:26 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:07:57 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21928-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194077.094193,VS0,VE399
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_tg32iahzctjuretmquyx3ykc6m","reference":"18D05F3ECC","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_lm63wuapkqculicy3bc4bzj3sy"}}}'
+      string: '{"action_id":"act_3z4nlrpnjgeuxbddi5zhasr6eu","reference":"01655CBB31","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_iafledv5gz7ezleugdlzlk7uvm"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:27 GMT
+  recorded_at: Tue, 19 Nov 2019 20:07:57 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/checkoutdotcom/purchase_refund.yml
+++ b/test/vcr_cassettes/checkoutdotcom/purchase_refund.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_jem42a5hn6gu7nhbfyqprbcbaa
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 94d7c027-90e1-424b-befd-1243f02178fa
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:28 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_jem42a5hn6gu7nhbfyqprbcbaa","action_id":"act_jem42a5hn6gu7nhbfyqprbcbaa","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"944648","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:28Z","processing":{"acquirer_transaction_id":"8138703071","retrieval_reference_number":"000944648529"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_jem42a5hn6gu7nhbfyqprbcbaa"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_jem42a5hn6gu7nhbfyqprbcbaa/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_jem42a5hn6gu7nhbfyqprbcbaa/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_jem42a5hn6gu7nhbfyqprbcbaa/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:28 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_jem42a5hn6gu7nhbfyqprbcbaa/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 1ab5e10f-1fc4-4d1a-b864-93e8dbbad98a
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:29 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_htm2zpba6l5uvlfeah3wxu2nkq","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_jem42a5hn6gu7nhbfyqprbcbaa"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:29 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":null}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1485'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1360'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_ob5mbfzjxnwenksgtph2pxosbq
+      - https://api.sandbox.checkout.com/payments/pay_4mtswut7xmxullkwf2fandw5jy
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 51f0d77e-3336-43f5-ba1f-8635b541d6b4
+      - 1c088353-acf3-43e8-9daf-c224bdc73962
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,22 +56,33 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:30 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:07:53 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21939-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194073.834489,VS0,VE415
     body:
       encoding: UTF-8
-      string: '{"id":"pay_ob5mbfzjxnwenksgtph2pxosbq","action_id":"act_ob5mbfzjxnwenksgtph2pxosbq","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"152148","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_4mtswut7xmxullkwf2fandw5jy","action_id":"act_4mtswut7xmxullkwf2fandw5jy","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"488638","eci":"05","scheme_id":"043819598651571","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_rwbfsqk744pujpcqyrc77aalzy","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:30Z","processing":{"acquirer_transaction_id":"8138703074","retrieval_reference_number":"000152148277"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_ob5mbfzjxnwenksgtph2pxosbq"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_ob5mbfzjxnwenksgtph2pxosbq/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_ob5mbfzjxnwenksgtph2pxosbq/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_ob5mbfzjxnwenksgtph2pxosbq/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_j7brvs5yjc5urat47njykwe33a","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:07:53Z","processing":{"acquirer_transaction_id":"9155105867","retrieval_reference_number":"657688202046"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_4mtswut7xmxullkwf2fandw5jy"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_4mtswut7xmxullkwf2fandw5jy/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_4mtswut7xmxullkwf2fandw5jy/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_4mtswut7xmxullkwf2fandw5jy/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:30 GMT
+  recorded_at: Tue, 19 Nov 2019 20:07:53 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_ob5mbfzjxnwenksgtph2pxosbq/captures
+    uri: https://api.sandbox.checkout.com/payments/pay_4mtswut7xmxullkwf2fandw5jy/captures
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -215,12 +104,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '151'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '151'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -228,9 +119,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 6fa53679-5ba8-487e-9d0a-156d151ffc0a
+      - 80688335-f15e-409d-837b-bb9f43fde5a4
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -241,18 +132,28 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:31 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:07:53 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21921-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194073.356524,VS0,VE401
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_ehuxqp6tivlexbo7tvywzmw55u","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_ob5mbfzjxnwenksgtph2pxosbq"}}}'
+      string: '{"action_id":"act_cjlwlqhejyru3f2afy4hlhmjgy","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_4mtswut7xmxullkwf2fandw5jy"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:31 GMT
+  recorded_at: Tue, 19 Nov 2019 20:07:53 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_ob5mbfzjxnwenksgtph2pxosbq/refunds
+    uri: https://api.sandbox.checkout.com/payments/pay_4mtswut7xmxullkwf2fandw5jy/refunds
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -274,12 +175,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '151'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '151'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -287,9 +190,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 0a828d18-f611-4b66-bec9-77c8a0c48d47
+      - 9d919f47-daed-4f3a-9a7c-9b1dd3b237db
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -300,13 +203,23 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:32 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:07:54 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21936-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194074.064393,VS0,VE426
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_kxunimrtyqaulnxklrqbgf4wbi","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_ob5mbfzjxnwenksgtph2pxosbq"}}}'
+      string: '{"action_id":"act_yoflzjpmm2de5ks4z4rz653v2q","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_4mtswut7xmxullkwf2fandw5jy"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:32 GMT
+  recorded_at: Tue, 19 Nov 2019 20:07:54 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/checkoutdotcom/store_auth.yml
+++ b/test/vcr_cassettes/checkoutdotcom/store_auth.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_mii43oerrrnelno3kd7td2wqam
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 978ffcbe-e7f0-4f18-be77-d22c827ebb95
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:34 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_mii43oerrrnelno3kd7td2wqam","action_id":"act_mii43oerrrnelno3kd7td2wqam","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"571015","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:34Z","processing":{"acquirer_transaction_id":"8138703080","retrieval_reference_number":"000571015088"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_mii43oerrrnelno3kd7td2wqam"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_mii43oerrrnelno3kd7td2wqam/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_mii43oerrrnelno3kd7td2wqam/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_mii43oerrrnelno3kd7td2wqam/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:34 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_mii43oerrrnelno3kd7td2wqam/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - d6fcd302-37b6-4feb-9eb0-fa7780c850fd
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:35 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_mb4ficuhygfufoque63t6jsgae","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_mii43oerrrnelno3kd7td2wqam"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:35 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":"F4C547FA8D","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":"7CAC20CE85","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":"user@workarea.com"}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1538'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1385'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_bmc5idlhfk4etpmvs2jfw2clzu
+      - https://api.sandbox.checkout.com/payments/pay_zbt4jjlnwn3uvb45bhcw6probm
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - f2e80423-5345-4175-badd-81075b71de0c
+      - 9e767175-532a-4590-827d-ccd12e6bdb93
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,17 +56,28 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:36 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:07:55 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21944-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194075.250703,VS0,VE396
     body:
       encoding: UTF-8
-      string: '{"id":"pay_bmc5idlhfk4etpmvs2jfw2clzu","action_id":"act_bmc5idlhfk4etpmvs2jfw2clzu","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"015240","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_zbt4jjlnwn3uvb45bhcw6probm","action_id":"act_zbt4jjlnwn3uvb45bhcw6probm","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"044913","eci":"05","scheme_id":"817574151943287","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_toxd2yvjsdlelieckfowkotabq","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:36Z","reference":"F4C547FA8D","processing":{"acquirer_transaction_id":"8138703085","retrieval_reference_number":"000015240677"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_bmc5idlhfk4etpmvs2jfw2clzu"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_bmc5idlhfk4etpmvs2jfw2clzu/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_bmc5idlhfk4etpmvs2jfw2clzu/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_bmc5idlhfk4etpmvs2jfw2clzu/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_xwtxqa3y66euhnkwgpcwe7ijce","email":"user@workarea.com","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:07:55Z","reference":"7CAC20CE85","processing":{"acquirer_transaction_id":"8433063531","retrieval_reference_number":"856927868141"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_zbt4jjlnwn3uvb45bhcw6probm"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_zbt4jjlnwn3uvb45bhcw6probm/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_zbt4jjlnwn3uvb45bhcw6probm/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_zbt4jjlnwn3uvb45bhcw6probm/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:36 GMT
+  recorded_at: Tue, 19 Nov 2019 20:07:55 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/checkoutdotcom/store_purchase.yml
+++ b/test/vcr_cassettes/checkoutdotcom/store_purchase.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_dhe6xurpw7qe7icoi3vutienn4
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 294b3ebc-b7d3-4f3f-9e9c-14f463305d5a
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:18 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_dhe6xurpw7qe7icoi3vutienn4","action_id":"act_dhe6xurpw7qe7icoi3vutienn4","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"770729","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:18Z","processing":{"acquirer_transaction_id":"8138703051","retrieval_reference_number":"000770729080"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_dhe6xurpw7qe7icoi3vutienn4"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_dhe6xurpw7qe7icoi3vutienn4/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_dhe6xurpw7qe7icoi3vutienn4/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_dhe6xurpw7qe7icoi3vutienn4/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:18 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_dhe6xurpw7qe7icoi3vutienn4/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - c5a78afc-ff67-4842-aea0-751c562f7185
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:00:19 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_h7dxzzcciftetifqjn2xhgrtwq","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_dhe6xurpw7qe7icoi3vutienn4"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:19 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":null}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1485'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1360'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_33mwtb3o4qsunofguuqtwk23oe
+      - https://api.sandbox.checkout.com/payments/pay_rtkfe7hma3eerliem62zwtozqm
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 7057c21f-087d-4f5f-93ed-89bad19eaeb9
+      - 3b3df819-1274-4bfd-b637-0ff28dbe1e59
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,22 +56,33 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:21 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:07:58 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21934-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194078.011267,VS0,VE407
     body:
       encoding: UTF-8
-      string: '{"id":"pay_33mwtb3o4qsunofguuqtwk23oe","action_id":"act_33mwtb3o4qsunofguuqtwk23oe","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"503966","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_rtkfe7hma3eerliem62zwtozqm","action_id":"act_rtkfe7hma3eerliem62zwtozqm","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"732316","eci":"05","scheme_id":"823258411803318","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_67e3fipsfsoe7iw2iwsiaxq6aq","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:00:20Z","processing":{"acquirer_transaction_id":"8138703055","retrieval_reference_number":"000503966617"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_33mwtb3o4qsunofguuqtwk23oe"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_33mwtb3o4qsunofguuqtwk23oe/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_33mwtb3o4qsunofguuqtwk23oe/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_33mwtb3o4qsunofguuqtwk23oe/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_bamj2bba6b5ebgv32dtc5ow2zi","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:07:58Z","processing":{"acquirer_transaction_id":"9025233614","retrieval_reference_number":"277776567210"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_rtkfe7hma3eerliem62zwtozqm"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_rtkfe7hma3eerliem62zwtozqm/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_rtkfe7hma3eerliem62zwtozqm/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_rtkfe7hma3eerliem62zwtozqm/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:21 GMT
+  recorded_at: Tue, 19 Nov 2019 20:07:58 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_33mwtb3o4qsunofguuqtwk23oe/captures
+    uri: https://api.sandbox.checkout.com/payments/pay_rtkfe7hma3eerliem62zwtozqm/captures
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -215,12 +104,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '151'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '151'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -228,9 +119,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 70c92945-cedc-4fb0-81d2-290ca9840f65
+      - 0f656d73-c407-43af-8442-9c2e97b90260
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -241,13 +132,23 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:00:22 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:07:59 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21943-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574194079.621586,VS0,VE410
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_mmfwr3nfueoe5aq5p5gwyimefm","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_33mwtb3o4qsunofguuqtwk23oe"}}}'
+      string: '{"action_id":"act_te3s3mbsizlezfu537gun6xwwe","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_rtkfe7hma3eerliem62zwtozqm"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:00:22 GMT
+  recorded_at: Tue, 19 Nov 2019 20:07:59 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/credit_card/auth_capture.yml
+++ b/test/vcr_cassettes/credit_card/auth_capture.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_jvt24sonlj7uzmmqx2nyrx36cq
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - c8e5c686-3ad7-43cc-a0cd-046f2b515300
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:04:52 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_jvt24sonlj7uzmmqx2nyrx36cq","action_id":"act_jvt24sonlj7uzmmqx2nyrx36cq","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"391214","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:04:52Z","processing":{"acquirer_transaction_id":"8138703257","retrieval_reference_number":"000391214747"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_jvt24sonlj7uzmmqx2nyrx36cq"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_jvt24sonlj7uzmmqx2nyrx36cq/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_jvt24sonlj7uzmmqx2nyrx36cq/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_jvt24sonlj7uzmmqx2nyrx36cq/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:52 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_jvt24sonlj7uzmmqx2nyrx36cq/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - a91213d0-8023-4644-88ff-fc4c5e324ba9
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:04:53 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_shx3noq262wunfyr5rwgzhladu","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_jvt24sonlj7uzmmqx2nyrx36cq"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:53 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":"25451CA977","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":"F59AA72E51","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":"user@workarea.com"}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1538'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1385'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_22hvfe43oy2ebgjlpkg5md3nku
+      - https://api.sandbox.checkout.com/payments/pay_3uizfgw3g6nujdjeg466kiyex4
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 8388103d-6681-4275-85f9-6d20cefc2120
+      - 9083561c-483b-4246-8d6a-115a63f62622
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,22 +56,33 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:04:53 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:19 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21921-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196499.020303,VS0,VE396
     body:
       encoding: UTF-8
-      string: '{"id":"pay_22hvfe43oy2ebgjlpkg5md3nku","action_id":"act_22hvfe43oy2ebgjlpkg5md3nku","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"029186","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_3uizfgw3g6nujdjeg466kiyex4","action_id":"act_3uizfgw3g6nujdjeg466kiyex4","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"270575","eci":"05","scheme_id":"929458365304749","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_toxd2yvjsdlelieckfowkotabq","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:04:53Z","reference":"25451CA977","processing":{"acquirer_transaction_id":"8138703260","retrieval_reference_number":"000029186031"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_22hvfe43oy2ebgjlpkg5md3nku"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_22hvfe43oy2ebgjlpkg5md3nku/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_22hvfe43oy2ebgjlpkg5md3nku/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_22hvfe43oy2ebgjlpkg5md3nku/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_xwtxqa3y66euhnkwgpcwe7ijce","email":"user@workarea.com","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:48:19Z","reference":"F59AA72E51","processing":{"acquirer_transaction_id":"7019299049","retrieval_reference_number":"467232870591"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_3uizfgw3g6nujdjeg466kiyex4"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_3uizfgw3g6nujdjeg466kiyex4/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_3uizfgw3g6nujdjeg466kiyex4/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_3uizfgw3g6nujdjeg466kiyex4/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:54 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:19 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_22hvfe43oy2ebgjlpkg5md3nku/captures
+    uri: https://api.sandbox.checkout.com/payments/pay_3uizfgw3g6nujdjeg466kiyex4/captures
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -215,12 +104,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '176'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '176'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -228,9 +119,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 9c19ae65-6827-4b2b-b881-a9e9369b4ab9
+      - 003b3c29-45e6-47c8-a740-9fb5428caa26
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -241,13 +132,23 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:04:53 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:20 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21924-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196500.735163,VS0,VE403
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_2p4l7sogw6aepd5y5d5hgb6boi","reference":"25451CA977","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_22hvfe43oy2ebgjlpkg5md3nku"}}}'
+      string: '{"action_id":"act_75bhx3oato7uhjw7kyoigarfci","reference":"F59AA72E51","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_3uizfgw3g6nujdjeg466kiyex4"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:54 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:20 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/credit_card/auth_capture_refund.yml
+++ b/test/vcr_cassettes/credit_card/auth_capture_refund.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_62ryx5ov2wiupogjtx3c3zo7ru
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 02aea5e1-6826-4120-8369-47831c73ecdf
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:04:55 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_62ryx5ov2wiupogjtx3c3zo7ru","action_id":"act_62ryx5ov2wiupogjtx3c3zo7ru","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"357327","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:04:55Z","processing":{"acquirer_transaction_id":"8138703263","retrieval_reference_number":"000357327722"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_62ryx5ov2wiupogjtx3c3zo7ru"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_62ryx5ov2wiupogjtx3c3zo7ru/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_62ryx5ov2wiupogjtx3c3zo7ru/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_62ryx5ov2wiupogjtx3c3zo7ru/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:56 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_62ryx5ov2wiupogjtx3c3zo7ru/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Version:
-      - 3.31.2
-      Request-Id:
-      - 04b83a94-6523-4866-8fa8-a90259b5b5c3
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:04:57 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_6mbiew2gshyurb3hixeieqryly","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_62ryx5ov2wiupogjtx3c3zo7ru"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:57 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":"B28094B9D8","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":"35D8194235","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":"user@workarea.com"}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1538'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1385'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_hgrqxbt24c5e3j622rgmgmq5km
+      - https://api.sandbox.checkout.com/payments/pay_iasssvvxqmeutms64xhycelgum
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 806f5da3-17b8-4419-95d4-93b74ee2c4b5
+      - 0c1f5f91-a889-4381-b775-d06c7a043261
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,22 +56,33 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:04:58 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:21 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21939-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196501.011011,VS0,VE366
     body:
       encoding: UTF-8
-      string: '{"id":"pay_hgrqxbt24c5e3j622rgmgmq5km","action_id":"act_hgrqxbt24c5e3j622rgmgmq5km","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"406442","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_iasssvvxqmeutms64xhycelgum","action_id":"act_iasssvvxqmeutms64xhycelgum","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"372096","eci":"05","scheme_id":"732757557197645","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_toxd2yvjsdlelieckfowkotabq","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:04:57Z","reference":"B28094B9D8","processing":{"acquirer_transaction_id":"8138703266","retrieval_reference_number":"000406442813"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_hgrqxbt24c5e3j622rgmgmq5km"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_hgrqxbt24c5e3j622rgmgmq5km/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_hgrqxbt24c5e3j622rgmgmq5km/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_hgrqxbt24c5e3j622rgmgmq5km/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_xwtxqa3y66euhnkwgpcwe7ijce","email":"user@workarea.com","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:48:21Z","reference":"35D8194235","processing":{"acquirer_transaction_id":"7742939863","retrieval_reference_number":"153266679327"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_iasssvvxqmeutms64xhycelgum"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_iasssvvxqmeutms64xhycelgum/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_iasssvvxqmeutms64xhycelgum/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_iasssvvxqmeutms64xhycelgum/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:58 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:21 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_hgrqxbt24c5e3j622rgmgmq5km/captures
+    uri: https://api.sandbox.checkout.com/payments/pay_iasssvvxqmeutms64xhycelgum/captures
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -215,12 +104,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '176'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '176'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -228,9 +119,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - c2b58b8b-e396-4c21-b9c3-8bde39b7e202
+      - 83c00e7d-0f37-4e34-845b-e7d4159a89fa
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -241,18 +132,28 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:04:59 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:22 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21920-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196502.641813,VS0,VE396
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_kbra5wvem3ae5jncnrmzuywgie","reference":"B28094B9D8","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_hgrqxbt24c5e3j622rgmgmq5km"}}}'
+      string: '{"action_id":"act_y3jfa4lgey7ufb2mekfzsf6gyu","reference":"35D8194235","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_iasssvvxqmeutms64xhycelgum"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:59 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:22 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_hgrqxbt24c5e3j622rgmgmq5km/refunds
+    uri: https://api.sandbox.checkout.com/payments/pay_iasssvvxqmeutms64xhycelgum/refunds
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -274,12 +175,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '176'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '176'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -287,9 +190,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - ee0f887b-2ec8-429a-a75b-dde86a55c92b
+      - 1fadae98-67a1-4288-8bff-f28fb239617a
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -300,13 +203,23 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:05:00 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:22 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21921-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196503.531330,VS0,VE182
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_db3ytetyerfuxe4bywcvav4g5e","reference":"B28094B9D8","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_hgrqxbt24c5e3j622rgmgmq5km"}}}'
+      string: '{"action_id":"act_bqjuzprhffju3jgocr7op5fpia","reference":"35D8194235","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_iasssvvxqmeutms64xhycelgum"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:00 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:22 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/credit_card/auth_void.yml
+++ b/test/vcr_cassettes/credit_card/auth_void.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_wlojbmf2bjuefc7ufjovyvkiny
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 0c6dd117-f2b5-4be7-9f09-4391283af273
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:05:10 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_wlojbmf2bjuefc7ufjovyvkiny","action_id":"act_wlojbmf2bjuefc7ufjovyvkiny","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"883188","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:05:09Z","processing":{"acquirer_transaction_id":"8138703288","retrieval_reference_number":"000883188491"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_wlojbmf2bjuefc7ufjovyvkiny"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_wlojbmf2bjuefc7ufjovyvkiny/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_wlojbmf2bjuefc7ufjovyvkiny/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_wlojbmf2bjuefc7ufjovyvkiny/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:10 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_wlojbmf2bjuefc7ufjovyvkiny/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - d4ca85eb-75c0-4e1c-97a6-b392ab43f19c
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:05:10 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_kkuzshfr3kqe3cdw2gub4ic2ny","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_wlojbmf2bjuefc7ufjovyvkiny"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:11 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":"D23B7DDF65","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":"E7077DBFCC","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":"user@workarea.com"}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1538'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1385'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_sxg65so4apzunbqwksgizbw6ce
+      - https://api.sandbox.checkout.com/payments/pay_rp2ym5fuwr4etlzvfds2ukc5na
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 8ac65562-3a91-408d-9440-d98c48153641
+      - 863bab02-3722-4c2a-8823-0970e8346926
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,22 +56,33 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:05:12 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:12 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21923-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196492.045680,VS0,VE421
     body:
       encoding: UTF-8
-      string: '{"id":"pay_sxg65so4apzunbqwksgizbw6ce","action_id":"act_sxg65so4apzunbqwksgizbw6ce","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"037042","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_rp2ym5fuwr4etlzvfds2ukc5na","action_id":"act_rp2ym5fuwr4etlzvfds2ukc5na","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"007336","eci":"05","scheme_id":"048275523262840","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_toxd2yvjsdlelieckfowkotabq","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:05:12Z","reference":"D23B7DDF65","processing":{"acquirer_transaction_id":"8138703290","retrieval_reference_number":"000037042516"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_sxg65so4apzunbqwksgizbw6ce"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_sxg65so4apzunbqwksgizbw6ce/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_sxg65so4apzunbqwksgizbw6ce/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_sxg65so4apzunbqwksgizbw6ce/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_xwtxqa3y66euhnkwgpcwe7ijce","email":"user@workarea.com","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:48:12Z","reference":"E7077DBFCC","processing":{"acquirer_transaction_id":"3105907791","retrieval_reference_number":"582097169439"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_rp2ym5fuwr4etlzvfds2ukc5na"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_rp2ym5fuwr4etlzvfds2ukc5na/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_rp2ym5fuwr4etlzvfds2ukc5na/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_rp2ym5fuwr4etlzvfds2ukc5na/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:12 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:12 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_sxg65so4apzunbqwksgizbw6ce/voids
+    uri: https://api.sandbox.checkout.com/payments/pay_rp2ym5fuwr4etlzvfds2ukc5na/voids
     body:
       encoding: UTF-8
       string: "{}"
@@ -215,12 +104,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '176'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '176'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -228,9 +119,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 9bbd112b-7f2d-49ce-905a-2e89f2e7a5c2
+      - 9df3edfb-e4da-4936-bdbd-74113acdc9c7
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -241,13 +132,23 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:05:13 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:13 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21943-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196493.748147,VS0,VE503
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_q2hid7zroalu3b6sgtax4plkpi","reference":"D23B7DDF65","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_sxg65so4apzunbqwksgizbw6ce"}}}'
+      string: '{"action_id":"act_dzxnqzvtltqejefu5zf23qp4aa","reference":"E7077DBFCC","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_rp2ym5fuwr4etlzvfds2ukc5na"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:13 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:13 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/credit_card/purchase_refund.yml
+++ b/test/vcr_cassettes/credit_card/purchase_refund.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_yiof2lrqydie3goiejxrs7guxe
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - b3ae1b60-6cfa-44c7-9eab-df484e7f9e5b
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:05:01 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_yiof2lrqydie3goiejxrs7guxe","action_id":"act_yiof2lrqydie3goiejxrs7guxe","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"182242","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:05:01Z","processing":{"acquirer_transaction_id":"8138703271","retrieval_reference_number":"000182242367"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_yiof2lrqydie3goiejxrs7guxe"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_yiof2lrqydie3goiejxrs7guxe/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_yiof2lrqydie3goiejxrs7guxe/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_yiof2lrqydie3goiejxrs7guxe/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:02 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_yiof2lrqydie3goiejxrs7guxe/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - '07855bf5-204a-44d8-963d-d6433d888164'
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:05:02 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_4duwxkvqniiuzk2yawr2x7sjae","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_yiof2lrqydie3goiejxrs7guxe"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:02 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":null}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1485'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1360'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_6el3mggz5rperlefm4vw44mcka
+      - https://api.sandbox.checkout.com/payments/pay_kg465yxcg5nuzmast5g2sdrzrq
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - b18f18cc-8556-4164-acd0-188151ca1938
+      - 5194738e-58b1-4d10-bafd-34ebf6c775cf
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,22 +56,33 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:05:03 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:16 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21943-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196497.604936,VS0,VE176
     body:
       encoding: UTF-8
-      string: '{"id":"pay_6el3mggz5rperlefm4vw44mcka","action_id":"act_6el3mggz5rperlefm4vw44mcka","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"672697","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_kg465yxcg5nuzmast5g2sdrzrq","action_id":"act_kg465yxcg5nuzmast5g2sdrzrq","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"856241","eci":"05","scheme_id":"674279811313235","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_huqbvwowatkevi5lvlwzycdcd4","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:05:03Z","processing":{"acquirer_transaction_id":"8138703275","retrieval_reference_number":"000672697402"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_6el3mggz5rperlefm4vw44mcka"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_6el3mggz5rperlefm4vw44mcka/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_6el3mggz5rperlefm4vw44mcka/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_6el3mggz5rperlefm4vw44mcka/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_uaznnchrgo6ulezhknck3oflwm","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:48:16Z","processing":{"acquirer_transaction_id":"4717817668","retrieval_reference_number":"762647833049"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_kg465yxcg5nuzmast5g2sdrzrq"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_kg465yxcg5nuzmast5g2sdrzrq/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_kg465yxcg5nuzmast5g2sdrzrq/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_kg465yxcg5nuzmast5g2sdrzrq/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:04 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:16 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_6el3mggz5rperlefm4vw44mcka/captures
+    uri: https://api.sandbox.checkout.com/payments/pay_kg465yxcg5nuzmast5g2sdrzrq/captures
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -215,12 +104,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '151'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '151'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -228,9 +119,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - dce0fd6c-d2b4-42e4-a469-634bde96cf97
+      - a4097e2b-db88-4711-8dfa-7de6b4bdc483
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -241,18 +132,28 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:05:04 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:17 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21929-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196497.887159,VS0,VE468
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_lqfrxhui467edpcztcrqhc4g2u","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_6el3mggz5rperlefm4vw44mcka"}}}'
+      string: '{"action_id":"act_3f6fipogsrxujoqvdorrf62q4q","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_kg465yxcg5nuzmast5g2sdrzrq"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:04 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:17 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_6el3mggz5rperlefm4vw44mcka/refunds
+    uri: https://api.sandbox.checkout.com/payments/pay_kg465yxcg5nuzmast5g2sdrzrq/refunds
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -274,12 +175,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '151'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '151'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -287,9 +190,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - 54856f39-63c5-46df-8e28-38cead0e7553
+      - 885611e0-50d3-4690-bff4-7e6fd86034d0
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -300,13 +203,23 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:05:04 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:18 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21940-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196498.685674,VS0,VE393
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_jahrx6h3f5rehkej44kyrqnyu4","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_6el3mggz5rperlefm4vw44mcka"}}}'
+      string: '{"action_id":"act_gvwn53nsiffejesepylin4osnm","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_kg465yxcg5nuzmast5g2sdrzrq"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:05 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:18 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/credit_card/store_auth.yml
+++ b/test/vcr_cassettes/credit_card/store_auth.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_5udg5hvzdchuvff5ts4x34dbse
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - b430f6f3-fa4e-4613-95a1-03a220f71e3e
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:05:06 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_5udg5hvzdchuvff5ts4x34dbse","action_id":"act_5udg5hvzdchuvff5ts4x34dbse","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"616718","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:05:06Z","processing":{"acquirer_transaction_id":"8138703281","retrieval_reference_number":"000616718604"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_5udg5hvzdchuvff5ts4x34dbse"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_5udg5hvzdchuvff5ts4x34dbse/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_5udg5hvzdchuvff5ts4x34dbse/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_5udg5hvzdchuvff5ts4x34dbse/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:07 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_5udg5hvzdchuvff5ts4x34dbse/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 89e7eb58-89dc-44e3-9a4e-59458e53c37d
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:05:07 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_y5mvsiqlajtepaocay7nic6p7a","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_5udg5hvzdchuvff5ts4x34dbse"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:08 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":"039AE8FCED","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":"22AD2D5D05","currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":"user@workarea.com"}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1538'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1385'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_njcuhwc7ypcufilwmzuly366x4
+      - https://api.sandbox.checkout.com/payments/pay_s64x52qiohiellgcuty3wy27u4
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - beff82ce-27f8-40ca-b46c-70f8478d35ca
+      - 7cee1844-5d44-4cba-88e0-7d160bc62f51
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,17 +56,28 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:05:08 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:14 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21920-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196494.717258,VS0,VE500
     body:
       encoding: UTF-8
-      string: '{"id":"pay_njcuhwc7ypcufilwmzuly366x4","action_id":"act_njcuhwc7ypcufilwmzuly366x4","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"307028","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_s64x52qiohiellgcuty3wy27u4","action_id":"act_s64x52qiohiellgcuty3wy27u4","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"581722","eci":"05","scheme_id":"121364426068054","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_toxd2yvjsdlelieckfowkotabq","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:05:08Z","reference":"039AE8FCED","processing":{"acquirer_transaction_id":"8138703285","retrieval_reference_number":"000307028668"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_njcuhwc7ypcufilwmzuly366x4"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_njcuhwc7ypcufilwmzuly366x4/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_njcuhwc7ypcufilwmzuly366x4/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_njcuhwc7ypcufilwmzuly366x4/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_xwtxqa3y66euhnkwgpcwe7ijce","email":"user@workarea.com","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:48:14Z","reference":"22AD2D5D05","processing":{"acquirer_transaction_id":"3871696070","retrieval_reference_number":"083843506557"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_s64x52qiohiellgcuty3wy27u4"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_s64x52qiohiellgcuty3wy27u4/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_s64x52qiohiellgcuty3wy27u4/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_s64x52qiohiellgcuty3wy27u4/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:05:08 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:14 GMT
 recorded_with: VCR 2.9.3

--- a/test/vcr_cassettes/credit_card/store_purchase.yml
+++ b/test/vcr_cassettes/credit_card/store_purchase.yml
@@ -5,132 +5,8 @@ http_interactions:
     uri: https://api.sandbox.checkout.com/payments
     body:
       encoding: UTF-8
-      string: '{"capture":false,"amount":"100","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
-        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01"},"customer":{"email":"user@workarea.com"}}'
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '1363'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Location:
-      - https://api.sandbox.checkout.com/payments/pay_3xczzndz2wyujdkooivj2lbifm
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - 6511e5a3-9583-4126-be9c-6ff29529a903
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:04:47 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"id":"pay_3xczzndz2wyujdkooivj2lbifm","action_id":"act_3xczzndz2wyujdkooivj2lbifm","amount":100,"currency":"USD","approved":true,"status":"Authorized","auth_code":"721461","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Ben
-        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
-        CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":"Y"},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:04:48Z","processing":{"acquirer_transaction_id":"8138703250","retrieval_reference_number":"000721461070"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_3xczzndz2wyujdkooivj2lbifm"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_3xczzndz2wyujdkooivj2lbifm/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_3xczzndz2wyujdkooivj2lbifm/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_3xczzndz2wyujdkooivj2lbifm/voids"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:48 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_3xczzndz2wyujdkooivj2lbifm/voids
-    body:
-      encoding: UTF-8
-      string: "{}"
-    headers:
-      Content-Type:
-      - application/json;charset=UTF-8
-      Authorization:
-      - sk_test_f4c1d728-928c-4381-bc6b-03c0888fb877
-      Connection:
-      - close
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Cache-Control:
-      - no-cache
-      Pragma:
-      - no-cache
-      Content-Length:
-      - '151'
-      Content-Type:
-      - application/json; charset=utf-8
-      Expires:
-      - "-1"
-      Product:
-      - Gateway
-      Cko-Version:
-      - 3.31.2
-      Cko-Request-Id:
-      - '03504950-e4ed-4300-bdf5-bdbe06f1bf5d'
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Headers:
-      - Origin,X-Requested-With,Content-Type,Accept,X-AuthToken,Access-Control-Request-Method,Access-Control-Allow-Methods,Access-Control-Request-Headers,authorization,X_Auth_Credentials
-      Access-Control-Allow-Methods:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Method:
-      - OPTIONS,POST,GET,PUT,DELETE
-      Access-Control-Request-Headers:
-      - authorization
-      Date:
-      - Fri, 12 Jul 2019 13:04:49 GMT
-      Connection:
-      - close
-    body:
-      encoding: UTF-8
-      string: '{"action_id":"act_o2uctlgpiyrujk337wvbqgyb6q","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_3xczzndz2wyujdkooivj2lbifm"}}}'
-    http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:49 GMT
-- request:
-    method: post
-    uri: https://api.sandbox.checkout.com/payments
-    body:
-      encoding: UTF-8
-      string: '{"capture":false,"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"id","id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","billing_address":{"address_line1":"22
+      string: '{"capture":false,"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"source":{"type":"card","name":"Ben
+        Crouse","number":"4242424242424242","cvv":100,"expiry_year":"2020","expiry_month":"01","billing_address":{"address_line1":"22
         s. 3rd st.","city":"Philadelphia","state":"PA","country":"US","zip":"19106"}},"customer":{"email":null}}'
     headers:
       Content-Type:
@@ -150,24 +26,26 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1485'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '1360'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
       - "-1"
       Location:
-      - https://api.sandbox.checkout.com/payments/pay_2jvql7ojhyxubd3mrpftekppoq
+      - https://api.sandbox.checkout.com/payments/pay_xxhlbitzb4zuboi5hra7qvfzc4
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - '028e193f-0094-45f2-8d25-a17ab0f5dc86'
+      - 67f0568d-0104-43b1-a2c0-9f6fd25d7789
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -178,22 +56,33 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:04:50 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:15 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21946-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196495.699457,VS0,VE425
     body:
       encoding: UTF-8
-      string: '{"id":"pay_2jvql7ojhyxubd3mrpftekppoq","action_id":"act_2jvql7ojhyxubd3mrpftekppoq","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"213284","eci":"05","scheme_id":"638284745624527","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_kgc7xfwp5gmuze7o3cuvcuunhu","type":"card","expiry_month":1,"expiry_year":2020,"name":"Web
-        User","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
+      string: '{"id":"pay_xxhlbitzb4zuboi5hra7qvfzc4","action_id":"act_xxhlbitzb4zuboi5hra7qvfzc4","amount":500,"currency":"USD","approved":true,"status":"Authorized","auth_code":"273451","eci":"05","scheme_id":"569047975377424","response_code":"10000","response_summary":"Approved","risk":{"flagged":false},"source":{"id":"src_tmywhzv2tg4epbpcjxq4hrpwnu","type":"card","billing_address":{"address_line1":"22
+        s. 3rd st.","city":"Philadelphia","state":"PA","zip":"19106","country":"US"},"expiry_month":1,"expiry_year":2020,"name":"Ben
+        Crouse","scheme":"Visa","last4":"4242","fingerprint":"A24ADA27CDDFF03B3607A0E4EA30E189F84B198ABDB346E39C3619982E7474AD","bin":"424242","card_type":"Credit","card_category":"Consumer","issuer":"JPMORGAN
         CHASE BANK NA","issuer_country":"US","product_id":"A","product_type":"Visa
-        Traditional","avs_check":"S","cvv_check":""},"customer":{"id":"cus_zwr2zdcuylfuhhgtk7yb7omxkq","email":"user@workarea.com","name":"Web
-        User"},"processed_on":"2019-07-12T13:04:50Z","processing":{"acquirer_transaction_id":"8138703253","retrieval_reference_number":"000213284421"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_2jvql7ojhyxubd3mrpftekppoq"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_2jvql7ojhyxubd3mrpftekppoq/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_2jvql7ojhyxubd3mrpftekppoq/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_2jvql7ojhyxubd3mrpftekppoq/voids"}}}'
+        Traditional","avs_check":"S","cvv_check":"Y","payouts":true,"fast_funds":"d"},"customer":{"id":"cus_ekiiy35rwvuezimk4v6atcernq","name":"Ben
+        Crouse"},"processed_on":"2019-11-19T20:48:15Z","processing":{"acquirer_transaction_id":"3086866314","retrieval_reference_number":"129718838535"},"_links":{"self":{"href":"https://api.sandbox.checkout.com/payments/pay_xxhlbitzb4zuboi5hra7qvfzc4"},"actions":{"href":"https://api.sandbox.checkout.com/payments/pay_xxhlbitzb4zuboi5hra7qvfzc4/actions"},"capture":{"href":"https://api.sandbox.checkout.com/payments/pay_xxhlbitzb4zuboi5hra7qvfzc4/captures"},"void":{"href":"https://api.sandbox.checkout.com/payments/pay_xxhlbitzb4zuboi5hra7qvfzc4/voids"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:50 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:15 GMT
 - request:
     method: post
-    uri: https://api.sandbox.checkout.com/payments/pay_2jvql7ojhyxubd3mrpftekppoq/captures
+    uri: https://api.sandbox.checkout.com/payments/pay_xxhlbitzb4zuboi5hra7qvfzc4/captures
     body:
       encoding: UTF-8
       string: '{"amount":"500","reference":null,"currency":"USD","metadata":{"udf5":"ActiveMerchant"},"customer":{"email":null}}'
@@ -215,12 +104,14 @@ http_interactions:
       code: 202
       message: Accepted
     headers:
+      Connection:
+      - close
+      Content-Length:
+      - '151'
       Cache-Control:
       - no-cache
       Pragma:
       - no-cache
-      Content-Length:
-      - '151'
       Content-Type:
       - application/json; charset=utf-8
       Expires:
@@ -228,9 +119,9 @@ http_interactions:
       Product:
       - Gateway
       Cko-Version:
-      - 3.31.2
+      - 3.32.9
       Cko-Request-Id:
-      - ffb5486a-cf0d-4ca1-a787-9cc7d7961b4c
+      - 0cb3589d-97f5-4a02-ac27-27cc18ba52fc
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -241,13 +132,23 @@ http_interactions:
       - OPTIONS,POST,GET,PUT,DELETE
       Access-Control-Request-Headers:
       - authorization
+      Accept-Ranges:
+      - bytes
       Date:
-      - Fri, 12 Jul 2019 13:04:51 GMT
-      Connection:
-      - close
+      - Tue, 19 Nov 2019 20:48:15 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lga21939-LGA
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1574196495.281584,VS0,VE608
     body:
       encoding: UTF-8
-      string: '{"action_id":"act_5zxdw4wmfsluxmodwgsaijbbju","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_2jvql7ojhyxubd3mrpftekppoq"}}}'
+      string: '{"action_id":"act_dozja76gzkbu7ixz3ha75mlyk4","_links":{"payment":{"href":"https://api.sandbox.checkout.com/payments/pay_xxhlbitzb4zuboi5hra7qvfzc4"}}}'
     http_version: 
-  recorded_at: Fri, 12 Jul 2019 13:04:51 GMT
+  recorded_at: Tue, 19 Nov 2019 20:48:15 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Checkout.com charges for every authorization transaction. Moving tokenzation to post
transaction helps reduce the extra cost for the merchant.

CHECKOUTDOTCOM-1